### PR TITLE
Added SemanticName property to SlangVar and SlangParameter

### DIFF
--- a/Slangc.NET/Models/SlangParameter.cs
+++ b/Slangc.NET/Models/SlangParameter.cs
@@ -17,6 +17,7 @@ public class SlangParameter
         UserAttributes = reader.ContainsKey("userAttribs") ? [.. reader["userAttribs"]!.AsArray().Select(static reader => new SlangUserAttribute(reader!.AsObject()))] : [];
         Bindings = reader.ContainsKey("bindings") ? [.. reader["bindings"]!.AsArray().Select(static reader => new SlangBinding(reader!.AsObject()))] : [new(reader["binding"]!.AsObject())];
         Type = new(reader["type"]!.AsObject());
+        SemanticName = reader.ContainsKey("semanticName") ? reader["semanticName"].Deserialize<string>() : null;
     }
 
     /// <summary>
@@ -38,4 +39,10 @@ public class SlangParameter
     /// Gets the type information for this parameter, including its structure and properties.
     /// </summary>
     public SlangType Type { get; }
+
+    /// <summary>
+    /// Gets the semantic name associated with this parameter, if it has one.
+    /// This is typically used for shader input/output parameters that are associated with specific semantics (e.g., POSITION, NORMAL, TEXCOORD).
+    /// </summary>
+    public string? SemanticName { get; }
 }

--- a/Slangc.NET/Models/SlangVar.cs
+++ b/Slangc.NET/Models/SlangVar.cs
@@ -16,6 +16,7 @@ public class SlangVar
         Name = reader["name"].Deserialize<string>();
         Type = new(reader["type"]!.AsObject());
         Binding = reader.ContainsKey("binding") ? new(reader["binding"]!.AsObject()) : null;
+        SemanticName = reader.ContainsKey("semanticName") ? reader["semanticName"].Deserialize<string>() : null;
     }
 
     /// <summary>
@@ -33,4 +34,10 @@ public class SlangVar
     /// May be null for variables that don't have explicit bindings.
     /// </summary>
     public SlangBinding? Binding { get; }
+
+    /// <summary>
+    /// Gets the semantic name associated with this variable, if it has one.
+    /// This is typically used for shader input/output variables that are associated with specific semantics (e.g., POSITION, NORMAL, TEXCOORD).
+    /// </summary>
+    public string? SemanticName { get; }
 }


### PR DESCRIPTION
Added the SemanticName property to parameters (SlangParameter) and variables (SlangVar) to help with slang shader handling in projects that need it