### PR TITLE
Fixed parameter failing to deserialize if no bindings are present

### DIFF
--- a/Slangc.NET/Models/SlangParameter.cs
+++ b/Slangc.NET/Models/SlangParameter.cs
@@ -15,7 +15,7 @@ public class SlangParameter
     {
         Name = reader["name"].Deserialize<string>();
         UserAttributes = reader.ContainsKey("userAttribs") ? [.. reader["userAttribs"]!.AsArray().Select(static reader => new SlangUserAttribute(reader!.AsObject()))] : [];
-        Bindings = reader.ContainsKey("bindings") ? [.. reader["bindings"]!.AsArray().Select(static reader => new SlangBinding(reader!.AsObject()))] : [new(reader["binding"]!.AsObject())];
+        Bindings = reader.ContainsKey("bindings") ? [.. reader["bindings"]!.AsArray().Select(static reader => new SlangBinding(reader!.AsObject()))] : reader.ContainsKey("binding") ? [new(reader["binding"]!.AsObject())] : [];
         Type = new(reader["type"]!.AsObject());
         SemanticName = reader.ContainsKey("semanticName") ? reader["semanticName"].Deserialize<string>() : null;
     }


### PR DESCRIPTION
When a shader's reflection json parameter doesn't have a bindings property, the deserialization fails. This small change fixes that